### PR TITLE
Include atmo corrected refl archives in AVIRIS catalog

### DIFF
--- a/catalogs/aviris/build_catalog.py
+++ b/catalogs/aviris/build_catalog.py
@@ -68,7 +68,7 @@ def find_s2_scenes():
                 s2_scenes[scene] = "ftp://{}:{}@{}/{}".format(
                     JPL_FTP_USERNAME, JPL_FTP_PASSWORD, JPL_FTP_HOSTNAME, s2_file
                 )
-    print("Found {} scenes with S2 data".format(len(s2_scenes.keys())))
+    print("Found {} scenes with refl data".format(len(s2_scenes.keys())))
     return s2_scenes
 
 
@@ -103,6 +103,7 @@ def map_series_to_item(s2_scenes_map, series):
             "NASA Log",
             "Investigator",
             "Comments",
+            "Name",
             "Flight Scene",
             "RDN Ver",
             "Scene",
@@ -190,7 +191,7 @@ def map_series_to_item(s2_scenes_map, series):
 def aviris_to_dataframe(aviris_csv):
 
     print("Loading AVIRIS data...")
-    df = pd.read_csv("aviris-flight-lines.csv")
+    df = pd.read_csv(aviris_csv)
     # Filter to only include flights with data
     df = df[(df["Gzip File Size (Bytes)"] > 0) & (df["Number of Samples"] > 0)]
 


### PR DESCRIPTION
## Overview

Adds an "ftp_refl" asset to all Items that have one. Retrieves all refl archives from FTP
and uses this list to find matches for each item.

Closes #51 

## Demo

![Screen Shot 2020-12-01 at 5 53 07 PM](https://user-images.githubusercontent.com/1818302/100806486-891cae00-33fe-11eb-85cd-0d4539d170fc.png)

![Screen Shot 2020-12-01 at 5 52 51 PM](https://user-images.githubusercontent.com/1818302/100806509-95a10680-33fe-11eb-9947-9dfa9c09f86d.png)

## Notes

There's a discrepancy in that theres ~1500 refl files on the FTP, but after running build_catalog.py we only end up with ~1350 Items with refl imagery added. Not sure where those are going, I'm digging a bit more.

## Testing Instructions

See #45, just need to delete `catalogs/aviris/data/catalog` directory and re-run `python build_catalog.py`. When it completes, each item will have an `ftp_refl` asset attached to it if it exists.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] README.md updated if necessary to reflect the changes
