### PR TITLE
Set up AWS Batch infrastructure

### DIFF
--- a/deployment/terraform/alarms.tf
+++ b/deployment/terraform/alarms.tf
@@ -1,3 +1,3 @@
 resource "aws_sns_topic" "global" {
-  name = "topic${replace(var.project, " ", "")}GlobalNotifications"
+  name = "topic${local.short}GlobalNotifications"
 }

--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -37,7 +37,7 @@ resource "aws_launch_template" "default" {
 }
 
 resource "aws_batch_compute_environment" "default" {
-  compute_environment_name_prefix = "batch${replace(var.project, " ", "")}"
+  compute_environment_name_prefix = "batch${local.short}"
   type                            = "MANAGED"
   state                           = "ENABLED"
   service_role                    = aws_iam_role.batch_service_role.arn
@@ -80,14 +80,14 @@ resource "aws_batch_compute_environment" "default" {
 }
 
 resource "aws_batch_job_queue" "default" {
-  name                 = "queue${replace(var.project, " ", "")}"
+  name                 = "queue${local.short}"
   priority             = 1
   state                = "ENABLED"
   compute_environments = [aws_batch_compute_environment.default.arn]
 }
 
 resource "aws_batch_job_definition" "download_test" {
-  name = "job${replace(var.project, " ", "")}DownloadTest"
+  name = "job${local.short}DownloadTest"
   type = "container"
 
   container_properties = templatefile("${path.module}/job-definitions/download-test.json.tmpl", {})

--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -1,0 +1,94 @@
+#
+# Security Group resources
+#
+resource "aws_security_group" "batch" {
+  name   = "sgBatchContainerInstance"
+  vpc_id = module.vpc.id
+
+  tags = {
+    Name        = "sgBatchContainerInstance"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+# Pull the image ID for the latest Amazon ECS optimized AMI
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+data "aws_ssm_parameter" batch_ami_id {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+}
+
+#
+# Batch resources
+#
+resource "aws_launch_template" "default" {
+  name_prefix = "ltBatchContainerInstance-"
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+
+    ebs {
+      volume_size = var.batch_root_block_device_size
+      volume_type = var.batch_root_block_device_type
+    }
+  }
+
+  user_data = base64encode(file("cloud-config/batch-container-instance"))
+}
+
+resource "aws_batch_compute_environment" "default" {
+  compute_environment_name_prefix = "batch${replace(var.project, " ", "")}"
+  type                            = "MANAGED"
+  state                           = "ENABLED"
+  service_role                    = aws_iam_role.batch_service_role.arn
+
+  compute_resources {
+    type                = "SPOT"
+    allocation_strategy = var.batch_spot_fleet_allocation_strategy
+    bid_percentage      = var.batch_spot_fleet_bid_percentage
+    ec2_key_pair        = var.aws_key_name
+    image_id            = data.aws_ssm_parameter.batch_ami_id.value
+
+    min_vcpus = var.batch_min_vcpus
+    max_vcpus = var.batch_max_vcpus
+
+    launch_template {
+      launch_template_id = aws_launch_template.default.id
+      version            = aws_launch_template.default.latest_version
+    }
+
+    spot_iam_fleet_role = aws_iam_role.spot_fleet_service_role.arn
+    instance_role       = aws_iam_instance_profile.ecs_instance_role.arn
+
+    instance_type = var.batch_instance_types
+
+    security_group_ids = [aws_security_group.batch.id]
+    subnets            = module.vpc.private_subnet_ids
+
+    tags = {
+      Name        = "BatchWorker"
+      Project     = var.project
+      Environment = var.environment
+    }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.batch_service_role_policy]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_batch_job_queue" "default" {
+  name                 = "queue${replace(var.project, " ", "")}"
+  priority             = 1
+  state                = "ENABLED"
+  compute_environments = [aws_batch_compute_environment.default.arn]
+}
+
+resource "aws_batch_job_definition" "download_test" {
+  name = "job${replace(var.project, " ", "")}DownloadTest"
+  type = "container"
+
+  container_properties = templatefile("${path.module}/job-definitions/download-test.json.tmpl", {})
+}

--- a/deployment/terraform/cloud-config/batch-container-instance
+++ b/deployment/terraform/cloud-config/batch-container-instance
@@ -1,0 +1,18 @@
+Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+MIME-Version: 1.0
+
+--==BOUNDARY==
+Content-Type: text/cloud-boothook; charset="us-ascii"
+
+# Manually mount unformatted instance store volumes. Mounting in a cloud-boothook
+# makes it more likely the drive is mounted before the Docker daemon and ECS agent
+# start, which helps mitigate potential race conditions.
+#
+# See:
+# - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bootstrap_container_instance.html#bootstrap_docker_daemon
+# - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-ami-basics.html#supported-user-data-formats
+mkfs.ext4 -E nodiscard /dev/nvme1n1
+mkdir -p /media/ephemeral0
+mount -t ext4 -o defaults,nofail,discard /dev/nvme1n1 /media/ephemeral0
+
+--==BOUNDARY==

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -135,3 +135,36 @@ resource "aws_security_group_rule" "franklin_rds_egress" {
   security_group_id        = aws_security_group.franklin.id
   source_security_group_id = module.database.database_security_group_id
 }
+
+#
+# Batch container instance security group resources
+#
+resource "aws_security_group_rule" "batch_http_egress" {
+  type        = "egress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = aws_security_group.batch.id
+}
+
+resource "aws_security_group_rule" "batch_https_egress" {
+  type        = "egress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = aws_security_group.batch.id
+}
+
+resource "aws_security_group_rule" "batch_bastion_ingress" {
+  type      = "ingress"
+  from_port = 22
+  to_port   = 22
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.batch.id
+  source_security_group_id = module.vpc.bastion_security_group_id
+}

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -1,3 +1,109 @@
+#
+# Batch IAM resources
+#
+data "aws_iam_policy_document" "batch_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["batch.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "batch_service_role" {
+  name               = "batchServiceRole"
+  assume_role_policy = data.aws_iam_policy_document.batch_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "batch_service_role_policy" {
+  role       = aws_iam_role.batch_service_role.name
+  policy_arn = var.aws_batch_service_role_policy_arn
+}
+
+#
+# Spot Fleet IAM resources
+#
+data "aws_iam_policy_document" "spot_fleet_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["spotfleet.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "spot_fleet_service_role" {
+  name               = "fleetServiceRole"
+  assume_role_policy = data.aws_iam_policy_document.spot_fleet_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "spot_fleet_service_role_policy" {
+  role       = aws_iam_role.spot_fleet_service_role.name
+  policy_arn = var.aws_spot_fleet_service_role_policy_arn
+}
+
+#
+# EC2 IAM resources
+#
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "ecs_instance_role" {
+  name               = "ecsInstanceRole"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_service_role_policy" {
+  role       = aws_iam_role.ecs_instance_role.name
+  policy_arn = var.aws_ec2_service_role_policy_arn
+}
+
+resource "aws_iam_instance_profile" "ecs_instance_role" {
+  name = aws_iam_role.ecs_instance_role.name
+  role = aws_iam_role.ecs_instance_role.name
+}
+
+data "aws_iam_policy_document" "scoped_read_write" {
+  statement {
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::aviris-data",
+      "arn:aws:s3:::aviris-data/*",
+    ]
+
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "scoped_read_write" {
+  name   = "s3ScopedReadWritePolicy"
+  role   = aws_iam_role.ecs_instance_role.name
+  policy = data.aws_iam_policy_document.scoped_read_write.json
+}
 
 #
 # ECS IAM resources

--- a/deployment/terraform/job-definitions/download-test.json.tmpl
+++ b/deployment/terraform/job-definitions/download-test.json.tmpl
@@ -1,0 +1,27 @@
+{
+    "image": "amazon/aws-cli",
+    "vcpus": 1,
+    "memory": 1024,
+    "command": [
+        "s3",
+        "cp",
+        "s3://aviris-data/test/f130329t01p00r06_corr_v1.tiff",
+        "/tmp"
+    ],
+    "volumes": [
+        {
+            "host": {
+                "sourcePath": "/media/ephemeral0"
+            },
+            "name": "ephemeral0"
+        }
+    ],
+    "mountPoints": [
+        {
+            "containerPath": "/tmp",
+            "readOnly": false,
+            "sourceVolume": "ephemeral0"
+        }
+    ],
+    "privileged": false
+}

--- a/deployment/terraform/network.tf
+++ b/deployment/terraform/network.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   source = "github.com/azavea/terraform-aws-vpc?ref=6.0.1"
 
-  name                       = "vpc${replace(var.project, " ", "")}"
+  name                       = "vpc${local.short}"
   region                     = var.aws_region
   key_name                   = var.aws_key_name
   cidr_block                 = var.vpc_cidr_block

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -224,7 +224,7 @@ variable "batch_root_block_device_size" {
 }
 
 variable "batch_root_block_device_type" {
-  default = "gp2"
+  default = "gp3"
   type    = string
 }
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -214,6 +214,42 @@ variable "rds_cpu_credit_balance_threshold" {
   type    = number
 }
 
+variable "batch_root_block_device_size" {
+  default = 32
+  type    = number
+}
+
+variable "batch_root_block_device_type" {
+  default = "gp2"
+  type    = string
+}
+
+variable "batch_spot_fleet_allocation_strategy" {
+  default = "SPOT_CAPACITY_OPTIMIZED"
+  type    = string
+}
+
+variable "batch_spot_fleet_bid_percentage" {
+  default = 64
+  type    = number
+}
+
+variable "batch_min_vcpus" {
+  default = 0
+  type    = number
+}
+
+variable "batch_max_vcpus" {
+  default = 256
+  type    = number
+}
+
+variable "batch_instance_types" {
+  default = ["c5d", "m5d"]
+
+  type = list(string)
+}
+
 variable "fargate_platform_version" {
   default = "1.4.0"
 }
@@ -240,6 +276,21 @@ variable "franklin_cpu" {
 
 variable "franklin_memory" {
   type = number
+}
+
+variable "aws_batch_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+  type    = string
+}
+
+variable "aws_spot_fleet_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
+  type    = string
+}
+
+variable "aws_ec2_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+  type    = string
 }
 
 variable "aws_ecs_task_execution_role_policy_arn" {

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -3,6 +3,10 @@ variable "project" {
   type    = string
 }
 
+locals {
+  short = replace(var.project, " ", "")
+}
+
 variable "environment" {
   default = "Staging"
   type    = string


### PR DESCRIPTION
## Overview

Add Terraform configuration for an AWS Batch compute environment. This includes supporting resources such as a job queue, an example job definition, an EC2 launch template, security group rules, and IAM roles.

Resolves #38 

## Testing Instructions

- From the Batch console, select [**Submit new job**](https://console.aws.amazon.com/batch/v2/home?region=us-east-1#jobs/new)
- Select the following
  - **Name:** `test`
  - **Job definition:** `jobNASAHyperspectralDownloadTest:N`
  - **Job queue:** `queueNASAHyperspectral`
- Click **Submit**

See the results of the job: https://console.aws.amazon.com/batch/v2/home?region=us-east-1#jobs/detail/a3860d42-af1e-44b2-b93e-aa922aa360d5

```bash
. . .
Completed 12.9 GiB/12.9 GiB (292.1 MiB/s) with 1 file(s) remaining 
download: s3://aviris-data/test/f130329t01p00r06_corr_v1.tiff to ../tmp/f130329t01p00r06_corr_v1.tiff
```

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] README.md updated if necessary to reflect the changes
