### PR TITLE
Flatten AVIRIS data catalog

### DIFF
--- a/catalogs/README.md
+++ b/catalogs/README.md
@@ -6,7 +6,7 @@ This folder contains a series of scripts used to generate STAC Catalogs for this
 
 | Catalog Name | Folder | Published Location |
 |--------------|--------|--------------------|
-| AVIRIS       | aviris | `s3://aviris-data/stac-catalog/collection.json` |
+| AVIRIS       | aviris | `s3://aviris-data/stac-catalog/catalog.json` |
 
 ## Generating Catalogs
 

--- a/catalogs/README.md
+++ b/catalogs/README.md
@@ -6,7 +6,7 @@ This folder contains a series of scripts used to generate STAC Catalogs for this
 
 | Catalog Name | Folder | Published Location |
 |--------------|--------|--------------------|
-| AVIRIS       | aviris | `s3://aviris-data/stac-catalog/catalog.json` |
+| AVIRIS       | aviris | `s3://aviris-data/stac-catalog/collection.json` |
 
 ## Generating Catalogs
 

--- a/catalogs/aviris/build_catalog.py
+++ b/catalogs/aviris/build_catalog.py
@@ -218,8 +218,8 @@ def aviris_to_dataframe(aviris_csv):
 def main():
     df = aviris_to_dataframe("aviris-flight-lines.csv")
 
-    catalog = pystac.Collection(
-        "aviris-data",
+    collection = pystac.Collection(
+        "aviris-collection",
         AVIRIS_DESCRIPTION,
         pystac.Extent(
             spatial=pystac.SpatialExtent([[None, None, None, None]]),
@@ -228,7 +228,9 @@ def main():
             ),
         ),
     )
-    stacframes.df_to(catalog, df)
+    stacframes.df_to(collection, df)
+    catalog = pystac.Catalog("aviris", AVIRIS_DESCRIPTION)
+    catalog.add_child(collection)
 
     # Normalize before validation to set all the required object links
     catalog_path = "./data/catalog"

--- a/catalogs/aviris/build_catalog.py
+++ b/catalogs/aviris/build_catalog.py
@@ -218,10 +218,16 @@ def aviris_to_dataframe(aviris_csv):
 def main():
     df = aviris_to_dataframe("aviris-flight-lines.csv")
 
-    df = stacframes.parents.from_properties_accum(
-        ["Year", "Flight"], df, prefix="aviris", separator="_"
+    catalog = pystac.Collection(
+        "aviris-data",
+        AVIRIS_DESCRIPTION,
+        pystac.Extent(
+            spatial=pystac.SpatialExtent([[None, None, None, None]]),
+            temporal=pystac.TemporalExtent(
+                [[datetime(1970, 1, 1, tzinfo=timezone.utc), None]]
+            ),
+        ),
     )
-    catalog = pystac.Catalog("aviris", AVIRIS_DESCRIPTION)
     stacframes.df_to(catalog, df)
 
     # Normalize before validation to set all the required object links


### PR DESCRIPTION
## Overview

Having nested collections ingested into Franklin doesn't really gain us anything, since we can use the query extension to filter on the Year and Flight properties for the same effect. It also cluttered the collections endpoint. This PR flattens the AVIRIS catalog to a single root collection. I've already ingested it into the NASA Franklin instance.

Connects #55

## Demo

![Screen Shot 2020-12-07 at 4 07 00 PM](https://user-images.githubusercontent.com/1818302/101405553-3f244400-38a6-11eb-8aa9-85ed7774bfa0.png)

## Testing Instructions

Generate AVIRIS data catalog. It should be a flat catalog with a Collection as root named `aviris-data`.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] README.md updated if necessary to reflect the changes
