### PR TITLE
AVIRIS L2 Activator

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,23 @@ An event-driven image processing pipeline for developing our foundational capabi
 - [STAC Catalogs](#stac-catalogs)
 - [Scripts](#scripts)
 
+## Requirements
+
+- Docker
+- Docker Compose
+
+## Setup
+
+Run `./scripts/setup`.
+
+## Development
+
+Run the local Franklin instance with `./scripts/server`. It is available at http://localhost:9090.
+
+Build and ingest the AVIRIS catalog into Franklin with `./scripts/catalogs-aviris`. The [catalogs README](./catalogs/README.md) has more information.
+
+Run the AVIRIS L2 activator in dev mode with `./scripts/run-activiator-l2-aviris`
+
 ## Scripts
 
 | Name    | Description                                                 |
@@ -18,22 +35,3 @@ An event-driven image processing pipeline for developing our foundational capabi
 | `server` | Start application servers, including Franklin |
 | `setup` | Run project setup after checkout |
 | `update` | Update project dependencies and rebuild containers |
-
-## Application
-
-### Requirements
-
-- Docker
-- Docker Compose
-
-### Setup
-
-Run `./scripts/setup`.
-
-### Development
-
-Run the local Franklin instance with `./scripts/server`. It is available at http://localhost:9090.
-
-Build and ingest the AVIRIS catalog into Franklin with `./scripts/catalogs-aviris`. The [catalogs README](./catalogs/README.md) has more information.
-
-Run the AVIRIS L2 activator in dev mode with `./scripts/run-activiator-l2-aviris`

--- a/README.md
+++ b/README.md
@@ -9,8 +9,31 @@ An event-driven image processing pipeline for developing our foundational capabi
 
 | Name    | Description                                                 |
 |---------|-------------------------------------------------------------|
+| `catalogs-aviris` | Generate a STAC Catalog for AVIRIS data |
+| `console` | Open a shell in the `dev` container |
+| `db-console` | Open a psql shell on the `database` container |
 | `infra` | Execute Terraform subcommands with remote state management. |
+| `migrate` | Run database migrations |
+| `run-activator-aviris-l2` | Run the AVIRIS L2 Activator in the development environment |
+| `server` | Start application servers, including Franklin |
+| `setup` | Run project setup after checkout |
+| `update` | Update project dependencies and rebuild containers |
 
-## STAC Catalogs
+## Application
 
-See the [catalogs README](./catalogs/README.md) for more information on catalog locations and how to build, run, and upload them.
+### Requirements
+
+- Docker
+- Docker Compose
+
+### Setup
+
+Run `./scripts/setup`.
+
+### Development
+
+Run the local Franklin instance with `./scripts/server`. It is available at http://localhost:9090.
+
+Build and ingest the AVIRIS catalog into Franklin with `./scripts/catalogs-aviris`. The [catalogs README](./catalogs/README.md) has more information.
+
+Run the AVIRIS L2 activator in dev mode with `./scripts/run-activiator-l2-aviris`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,37 @@
-version: '3'
+version: "3"
 
 services:
+  database:
+    image: quay.io/azavea/postgis:3-postgres12.4-slim
+    environment:
+      - POSTGRES_USER=franklin
+      - POSTGRES_PASSWORD=franklin
+      - POSTGRES_DB=franklin
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "franklin"]
+      interval: 3s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+  franklin:
+    image: quay.io/azavea/franklin:c93f2ff
+    depends_on:
+      database:
+        condition: service_healthy
+    command:
+      - serve
+    environment:
+      - ENVIRONMENT=development
+      - DB_HOST=database.service.internal
+      - DB_NAME=franklin
+      - DB_USER=franklin
+      - DB_PASSWORD=franklin
+      - AWS_PROFILE
+      - AWS_REGION
+    links:
+      - database:database.service.internal
+    ports:
+      - "9090:9090"
   app:
     build:
       context: .
@@ -12,6 +43,8 @@ services:
       - $HOME/.aws:/root/.aws:ro
     environment:
       - AWS_PROFILE=${AWS_PROFILE:-nasa}
+    links:
+      - franklin:franklin.service.internal
   dev:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,7 @@ services:
     depends_on:
       database:
         condition: service_healthy
-    command:
-      - serve
+    command: ["serve", "--with-transactions"]
     environment:
       - ENVIRONMENT=development
       - DB_HOST=database.service.internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.8"
 
 services:
   database:
@@ -7,28 +7,17 @@ services:
       - POSTGRES_USER=franklin
       - POSTGRES_PASSWORD=franklin
       - POSTGRES_DB=franklin
-    healthcheck:
-      test: ["CMD", "pg_isready", "-U", "franklin"]
-      interval: 3s
-      timeout: 3s
-      retries: 3
-      start_period: 5s
   franklin:
     image: quay.io/azavea/franklin:c93f2ff
-    depends_on:
-      database:
-        condition: service_healthy
     command: ["serve", "--with-transactions"]
     environment:
       - ENVIRONMENT=development
-      - DB_HOST=database.service.internal
+      - DB_HOST=database
       - DB_NAME=franklin
       - DB_USER=franklin
       - DB_PASSWORD=franklin
       - AWS_PROFILE
       - AWS_REGION
-    links:
-      - database:database.service.internal
     ports:
       - "9090:9090"
   app:
@@ -36,14 +25,12 @@ services:
       context: .
       dockerfile: Dockerfile
       target: app
+    environment:
+      - AWS_PROFILE=${AWS_PROFILE:-nasa}
     image: nasa-hyperspectral_app
     volumes:
       - .:/workspace:cached
       - $HOME/.aws:/root/.aws:ro
-    environment:
-      - AWS_PROFILE=${AWS_PROFILE:-nasa}
-    links:
-      - franklin:franklin.service.internal
   dev:
     build:
       context: .

--- a/pipeline/activators/aviris-cogify-l2/main.py
+++ b/pipeline/activators/aviris-cogify-l2/main.py
@@ -1,0 +1,270 @@
+import argparse
+from contextlib import contextmanager
+import ftplib
+import json
+from math import floor
+import os
+from pathlib import Path
+import shutil
+import sys
+import tarfile
+from tempfile import mkdtemp
+import threading
+from time import time
+from urllib.parse import urlparse, urlunparse
+
+import boto3
+from boto3.s3.transfer import TransferConfig
+from osgeo import gdal
+import pystac
+import requests
+
+
+GB = 1024 ** 3
+s3 = boto3.client("s3")
+
+AVIRIS_ARCHIVE_COLLECTION_ID = "aviris-data"
+AVIRIS_L2_COG_COLLECTION_ID = "aviris-l2-cogs"
+
+
+@contextmanager
+def timing(description: str) -> None:
+    start = time()
+    yield
+    elapsed = time() - start
+    print("{}: {:.4f}s".format(description, elapsed))
+
+
+class ProgressPercentage(object):
+    def __init__(self, filename):
+        self._filename = filename
+        self._size = float(os.path.getsize(filename))
+        self._seen_so_far = 0
+        self._lock = threading.Lock()
+
+    def __call__(self, bytes_amount):
+        # To simplify we'll assume this is hooked up
+        # to a single filename.
+        with self._lock:
+            self._seen_so_far += bytes_amount
+            percentage = (self._seen_so_far / self._size) * 100
+            sys.stdout.write(
+                "\r{}  {} / {} ({:.2f}%)".format(
+                    self._filename, self._seen_so_far, self._size, percentage
+                )
+            )
+            sys.stdout.flush()
+            if percentage >= 100:
+                print("")
+
+
+def translate_callback(progress, *args):
+    progress_pct = floor(progress * 100)
+    if progress_pct % 10 == 0 > progress_pct > 0:
+        print("GDAL Translate: {}%".format(progress_pct))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "aviris_stac_id",
+        type=str,
+        help="STAC Item ID to process from the {} STAC collection".format(
+            AVIRIS_ARCHIVE_COLLECTION_ID
+        ),
+    )
+    parser.add_argument(
+        "--franklin-hostname",
+        type=str,
+        default=os.environ.get("FRANKLIN_HOSTNAME", "franklin.nasa-hsi.azavea.com"),
+    )
+    parser.add_argument(
+        "--s3-bucket",
+        type=str,
+        default=os.environ.get("S3_BUCKET", "aviris-data"),
+    )
+    parser.add_argument(
+        "--s3-prefix",
+        type=str,
+        default=os.environ.get("S3_PREFIX", "aviris-scene-cogs-l2"),
+    )
+    parser.add_argument(
+        "--temp-dir", type=str, default=os.environ.get("TEMP_DIR", None)
+    )
+    parser.add_argument(
+        "--keep-temp-dir",
+        action="store_true",
+        help="If provided, script does not delete temporary directory before script exits. Useful for debugging.",
+    )
+    parser.add_argument(
+        "--skip-large",
+        action="store_true",
+        help="If provided, script will not process any COG > 200 MB to keep processing times reasonable. Useful for debugging.",
+    )
+    args = parser.parse_args()
+
+    # TODO: Check if COG item already exists and skip processing?
+    #       Maybe separate issue?
+
+    # POST Franklin /search for Name=<scene name> argument, retrieve STAC Item
+    franklin_url_path = str(
+        Path("collections", AVIRIS_ARCHIVE_COLLECTION_ID, "items", args.aviris_stac_id)
+    )
+    franklin_url = urlunparse(
+        ("https", args.franklin_hostname, franklin_url_path, None, None, None)
+    )
+    response = requests.get(franklin_url)
+    response.raise_for_status()
+    item = pystac.Item.from_dict(response.json())
+    l2_asset = item.assets.get("ftp_refl", None)
+    if l2_asset is None:
+        raise ValueError(
+            "STAC Item {} from {} has no asset 'ftp_refl'!".format(
+                args.aviris_stac_id, franklin_url
+            )
+        )
+    scene_name = item.properties.get("Name")
+
+    gzip_ftp_url = urlparse(l2_asset.href)
+    username_password, ftp_hostname = gzip_ftp_url.netloc.split("@")
+    ftp_username, ftp_password = username_password.split(":")
+
+    # Create tmpdir
+    temp_dir = Path(args.temp_dir if args.temp_dir is not None else mkdtemp())
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        # Retrieve AVIRIS GZIP for matching scene name
+        local_archive = Path(temp_dir, Path(l2_asset.href).name)
+        if local_archive.exists():
+            print("Using existing archive: {}".format(local_archive))
+        else:
+            with open(local_archive, "wb") as fp:
+                ftp_path = gzip_ftp_url.path.lstrip("/")
+                print("FTP RETR {}".format(ftp_path))
+                with timing("FTP RETR"):
+                    with ftplib.FTP(ftp_hostname) as ftp:
+                        ftp.login(ftp_username, ftp_password)
+                        ftp.retrbinary("RETR {}".format(ftp_path), fp.write)
+
+        # Retrieve file names from archive and extract if not already extracted to temp_dir
+        extract_path = Path(temp_dir, scene_name)
+        with tarfile.open(local_archive, mode="r") as tar_gz_fp:
+            print("Retrieving filenames from {}".format(local_archive))
+            with timing("Query archive"):
+                tar_files = tar_gz_fp.getnames()
+            # print("Files: {}".format(tar_files))
+
+            if extract_path.exists():
+                print("Skipping extract, exists at {}".format(extract_path))
+            else:
+                print("Extracting {} to {}".format(local_archive, extract_path))
+                with timing("Extract"):
+                    tar_gz_fp.extractall(extract_path)
+
+        # Create new COG STAC Item
+        cog_item_id = "{}-{}_{}".format(
+            AVIRIS_L2_COG_COLLECTION_ID,
+            item.properties.get("Name"),
+            item.properties.get("Scene"),
+        )
+        cog_item = pystac.Item(
+            cog_item_id,
+            item.geometry,
+            item.bbox,
+            item.datetime,
+            item.properties,
+            collection=AVIRIS_L2_COG_COLLECTION_ID,
+        )
+
+        # Find HDR data files in unzipped package
+        hdr_files = list(filter(lambda x: x.endswith(".hdr"), tar_files))
+        print("HDR Files: {}".format(hdr_files))
+        for idx, hdr_file_w_ext in enumerate(hdr_files):
+            hdr_file_w_ext_path = Path(hdr_file_w_ext)
+            hdr_path = Path(extract_path, hdr_file_w_ext_path.with_suffix(""))
+            cog_path = hdr_path.with_suffix(".tiff")
+
+            if args.skip_large and os.path.getsize(hdr_path) > 0.2 * GB:
+                file_mb = floor(os.path.getsize(hdr_path) / 1024 / 1024)
+                print(
+                    "--skip-large provided. Skipping {} with size {}mb".format(
+                        hdr_path, file_mb
+                    )
+                )
+                continue
+
+            # Convert HDR data to pixel interleaved COG with GDAL
+            # NUM_THREADS only speeds up compression and overview generation
+            translate_opts = gdal.TranslateOptions(
+                callback=translate_callback,
+                creationOptions=["NUM_THREADS=ALL_CPUS", "COMPRESS=DEFLATE"],
+                format="COG",
+            )
+            print("Converting {} to {}...".format(hdr_path, cog_path))
+            with timing("GDAL Translate"):
+                gdal.Translate(str(cog_path), str(hdr_path), options=translate_opts)
+
+            # Upload  COG and metadata, if written, to S3 bucket + key
+            key = Path(
+                args.s3_prefix,
+                str(item.properties.get("Year")),
+                str(item.properties.get("Name")),
+                cog_path.name,
+            )
+            s3_uri = "s3://{}/{}".format(args.s3_bucket, key)
+            print("Uploading {} to {}".format(cog_path, s3_uri))
+            s3.upload_file(
+                str(cog_path),
+                args.s3_bucket,
+                str(key),
+                Callback=ProgressPercentage(str(cog_path)),
+                Config=TransferConfig(multipart_threshold=1 * GB),
+            )
+            cog_metadata_path = cog_path.with_suffix(".tiff.aux.xml")
+            if cog_metadata_path.exists():
+                metadata_key = Path(args.s3_prefix, cog_metadata_path.name)
+                metadata_s3_uri = "s3://{}/{}".format(args.s3_bucket, metadata_key)
+                print("Uploading {} to {}".format(cog_metadata_path, metadata_s3_uri))
+                s3.upload_file(
+                    str(cog_metadata_path),
+                    args.s3_bucket,
+                    str(metadata_key),
+                )
+
+            # Add assets to COG STAC Item
+            cog_item.add_asset(
+                "cog_{}".format(idx),
+                pystac.Asset(s3_uri, media_type=pystac.MediaType.COG, roles=["data"]),
+            )
+            if cog_metadata_path.exists():
+                cog_item.add_asset(
+                    "metadata_{}".format(idx),
+                    pystac.Asset(
+                        metadata_s3_uri,
+                        media_type=pystac.MediaType.XML,
+                        roles=["metadata"],
+                    ),
+                )
+    finally:
+        if not args.keep_temp_dir:
+            print("Removing temp dir: {}".format(temp_dir))
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    franklin_url_path = str(Path("collections", AVIRIS_L2_COG_COLLECTION_ID, "items"))
+    franklin_url = urlunparse(
+        ("https", args.franklin_hostname, franklin_url_path, None, None, None)
+    )
+    print("POST Item {} to {}".format(cog_item.id, franklin_url))
+    response = requests.post(
+        franklin_url,
+        headers={"Content-Type": "application/json"},
+        data=json.dumps(cog_item.to_dict()),
+    )
+    response.raise_for_status()
+    post_data = response.json()
+    post_url = "/".join([franklin_url, post_data.get("id")])
+    print("Success: {}".format(post_url))
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/activators/aviris-l2/.gitignore
+++ b/pipeline/activators/aviris-l2/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+
+data

--- a/pipeline/activators/aviris-l2/main.py
+++ b/pipeline/activators/aviris-l2/main.py
@@ -53,7 +53,7 @@ def main():
         "--franklin-url",
         type=str,
         default=os.environ.get(
-            "AAL2_FRANKLIN_URL", "http://franklin.service.internal:9090"
+            "AAL2_FRANKLIN_URL", "http://franklin:9090"
         ),
     )
     parser.add_argument(

--- a/pipeline/activators/aviris-l2/main.py
+++ b/pipeline/activators/aviris-l2/main.py
@@ -74,19 +74,24 @@ def main():
         ),
     )
     parser.add_argument(
+        "--franklin-scheme",
+        type=str,
+        default=os.environ.get("AAL2_FRANKLIN_SCHEME", "http"),
+    )
+    parser.add_argument(
         "--franklin-hostname",
         type=str,
-        default=os.environ.get("FRANKLIN_HOSTNAME", "franklin.nasa-hsi.azavea.com"),
+        default=os.environ.get("AAL2_FRANKLIN_HOSTNAME", "franklin.service.internal:9090"),
     )
     parser.add_argument(
         "--s3-bucket",
         type=str,
-        default=os.environ.get("S3_BUCKET", "aviris-data"),
+        default=os.environ.get("AAL2_S3_BUCKET"),
     )
     parser.add_argument(
         "--s3-prefix",
         type=str,
-        default=os.environ.get("S3_PREFIX", "aviris-scene-cogs-l2"),
+        default=os.environ.get("AAL2_S3_PREFIX", "aviris-scene-cogs-l2"),
     )
     parser.add_argument(
         "--temp-dir", type=str, default=os.environ.get("TEMP_DIR", None)
@@ -111,7 +116,7 @@ def main():
         Path("collections", AVIRIS_ARCHIVE_COLLECTION_ID, "items", args.aviris_stac_id)
     )
     franklin_url = urlunparse(
-        ("https", args.franklin_hostname, franklin_url_path, None, None, None)
+        (args.franklin_scheme, args.franklin_hostname, franklin_url_path, None, None, None)
     )
     response = requests.get(franklin_url)
     response.raise_for_status()
@@ -252,7 +257,7 @@ def main():
 
     franklin_url_path = str(Path("collections", AVIRIS_L2_COG_COLLECTION_ID, "items"))
     franklin_url = urlunparse(
-        ("https", args.franklin_hostname, franklin_url_path, None, None, None)
+        (args.franklin_scheme, args.franklin_hostname, franklin_url_path, None, None, None)
     )
     print("POST Item {} to {}".format(cog_item.id, franklin_url))
     response = requests.post(

--- a/pipeline/activators/aviris-l2/main.py
+++ b/pipeline/activators/aviris-l2/main.py
@@ -296,7 +296,7 @@ def main():
     )
     if response.status_code == 404:
         requests.post(
-            "{}://{}/collections",
+            "{}://{}/collections".format(args.franklin_scheme, args.franklin_hostname),
             headers={"Content-Type": "application/json"},
             data=json.dumps(AVIRIS_L2_COG_COLLECTION),
         )

--- a/pipeline/activators/aviris-l2/progress.py
+++ b/pipeline/activators/aviris-l2/progress.py
@@ -1,0 +1,46 @@
+from contextlib import contextmanager
+from math import floor
+import os
+import sys
+import threading
+from time import time
+
+
+class ProgressPercentage(object):
+    """ Callable object for use with s3.upload_object callback """
+    def __init__(self, filename):
+        self._filename = filename
+        self._size = float(os.path.getsize(filename))
+        self._seen_so_far = 0
+        self._lock = threading.Lock()
+
+    def __call__(self, bytes_amount):
+        # To simplify we'll assume this is hooked up
+        # to a single filename.
+        with self._lock:
+            self._seen_so_far += bytes_amount
+            percentage = (self._seen_so_far / self._size) * 100
+            sys.stdout.write(
+                "\r{}  {} / {} ({:.2f}%)".format(
+                    self._filename, self._seen_so_far, self._size, percentage
+                )
+            )
+            sys.stdout.flush()
+            if percentage >= 100:
+                print("")
+
+
+@contextmanager
+def timing(description: str) -> None:
+    """ Prints time elapsed between context manager opened and closed """
+    start = time()
+    yield
+    elapsed = time() - start
+    print("{}: {:.4f}s".format(description, elapsed))
+
+
+def translate_callback(progress, *args):
+    """ Report progress for GDALTranslate callback argument """
+    progress_pct = floor(progress * 100)
+    if progress_pct % 10 == 0 > progress_pct > 0:
+        print("GDAL Translate: {}%".format(progress_pct))

--- a/pipeline/activators/aviris-l2/stac_client.py
+++ b/pipeline/activators/aviris-l2/stac_client.py
@@ -1,0 +1,51 @@
+import json
+
+import pystac
+import requests
+
+
+class STACClient:
+    def __init__(self, stac_api_url):
+        """ Create a new STACClient for stac_api_url
+
+        stac_api_url should include scheme, hostname, and port if applicable
+        Example: http://localhost:9090
+
+        """
+        self.stac_api_url = str(stac_api_url)
+
+    def get_collection_item(self, collection_id, item_id):
+        """ GET item pystac.Item from STAC API collection_id """
+        url = "{}/collections/{}/items/{}".format(
+            self.stac_api_url, collection_id, item_id
+        )
+        response = requests.get(url)
+        response.raise_for_status()
+        return pystac.Item.from_dict(response.json())
+
+    def has_collection(self, collection_id):
+        """ Return True if STAC API has collection_id Collection else False """
+        response = requests.get(
+            "{}/collections/{}".format(self.stac_api_url, collection_id)
+        )
+        return True if response.status_code < 300 else False
+
+    def post_collection(self, collection):
+        """ POST collection pystac.Collection to STAC API """
+        response = requests.post(
+            "{}/collections".format(self.stac_api_url),
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(collection.to_dict()),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def post_collection_item(self, collection_id, item):
+        """ POST item pystac.Item to collection_id """
+        response = requests.post(
+            "{}/collections/{}/items".format(self.stac_api_url, collection_id),
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(item.to_dict()),
+        )
+        response.raise_for_status()
+        return response.json()

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -1,6 +1,8 @@
 boto3==1.16.1
 fastkml==0.11
+gdal==3.2.0
 geopandas==0.8.1
 jsonschema==3.2.0
 pystac==0.5.3
+requests==2.25.0
 shapely==1.7.1

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -1,6 +1,6 @@
-boto3==1.16.1
+boto3==1.16.31
 fastkml==0.11
-gdal==3.2.0
+gdal==3.1.4
 geopandas==0.8.1
 jsonschema==3.2.0
 pystac==0.5.3

--- a/scripts/catalogs-aviris
+++ b/scripts/catalogs-aviris
@@ -24,10 +24,10 @@ then
                 --workdir="/workspace/catalogs/aviris" \
                 app build_catalog.py
 
-            echo "Importing catalog to Franklin. If this script is still running after 10 mins or so,"
-            echo 'check if all items are imported with `select count(*) from collection_items;`'
-            echo "in a psql shell. If they are, ctrl+c the import."
-            echo "There is a Franklin bug where sometimes imports do not exit."
+            echo "Importing catalog to Franklin. If this script is still running after a few minutes,"
+            echo 'check that `select count(*) from collection_items;` is still increasing '
+            echo "in a psql shell. If it isn't, ctrl+c the import."
+            echo "There is a Franklin bug where sometimes imports do not exit when complete."
 
             docker-compose run -v "$(pwd)/catalogs/aviris/data:/data:ro" --rm franklin \
                 import-catalog --catalog-root /data/catalog/catalog.json

--- a/scripts/catalogs-aviris
+++ b/scripts/catalogs-aviris
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Generate AVIRIS Catalog and then ingest into Franklin if not already available
+Example: ./scripts/ingest-aviris
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    case "${1}" in
+        --help)
+            usage
+            ;;
+        *)
+            ./scripts/server
+
+            docker-compose run \
+                --rm \
+                --entrypoint python \
+                --workdir="/workspace/catalogs/aviris" \
+                app build_catalog.py
+
+            docker-compose run -v "$(pwd)/catalogs/aviris/data:/data:ro" --rm franklin \
+                import-catalog --catalog-root /data/catalog/catalog.json
+
+            ;;
+    esac
+fi

--- a/scripts/catalogs-aviris
+++ b/scripts/catalogs-aviris
@@ -5,7 +5,7 @@ function usage() {
     echo -n \
 "Usage: $(basename "$0")
 Generate AVIRIS Catalog and then ingest into Franklin if not already available
-Example: ./scripts/ingest-aviris
+Example: ./scripts/catalogs-aviris
 "
 }
 
@@ -23,6 +23,11 @@ then
                 --entrypoint python \
                 --workdir="/workspace/catalogs/aviris" \
                 app build_catalog.py
+
+            echo "Importing catalog to Franklin. If this script is still running after 10 mins or so,"
+            echo 'check if all items are imported with `select count(*) from collection_items;`'
+            echo "in a psql shell. If they are, ctrl+c the import."
+            echo "There is a Franklin bug where sometimes imports do not exit."
 
             docker-compose run -v "$(pwd)/catalogs/aviris/data:/data:ro" --rm franklin \
                 import-catalog --catalog-root /data/catalog/catalog.json

--- a/scripts/catalogs-aviris
+++ b/scripts/catalogs-aviris
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if [[ -n "${NASA_HSI_DEBUG}" ]]; then
+    set -x
+fi
+
 function usage() {
     echo -n \
 "Usage: $(basename "$0")

--- a/scripts/console
+++ b/scripts/console
@@ -4,7 +4,7 @@ set -e
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Use Docker Compose to drop into a console in the dev container
+Use Docker Compose to start a console in the dev container
 Example: ./scripts/console
 "
 }

--- a/scripts/console
+++ b/scripts/console
@@ -1,22 +1,34 @@
 #!/bin/bash
+
 set -e
+
+if [[ -n "${NASA_HSI_DEBUG}" ]]; then
+    set -x
+fi
 
 function usage() {
     echo -n \
-"Usage: $(basename "$0")
-Use Docker Compose to start a console in the dev container
-Example: ./scripts/console
+        "Usage: $(basename "$0") SERVICE [COMMAND]...
+Run an interactive shell or command inside an application container.
+Example: ./scripts/console dev
+Services:
+    app         App container
+    dev         Dev container
 "
 }
 
-if [ "${BASH_SOURCE[0]}" = "${0}" ]
-then
-    case "${1}" in
-        --help)
-            usage
-            ;;
-        *)
-            docker-compose run --rm --entrypoint /bin/bash dev
-            ;;
-    esac
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    if (( $# == 0 )) || [[ "${1:-}" == "--help" ]]; then
+        usage
+    elif (( $# == 1 )); then
+        docker-compose \
+            run --rm --no-deps \
+            --entrypoint "/bin/bash" \
+            "$1"
+    else
+        docker-compose \
+            run --rm --no-deps \
+            --entrypoint "/bin/bash -c" \
+            "$1" "${*:2}"
+    fi
 fi

--- a/scripts/db-console
+++ b/scripts/db-console
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eu
+
+DIR="$(dirname "$0")"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Use Docker Compose to enter a psql shell on the local database container
+"
+}
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        docker-compose -f "${DIR}/../docker-compose.yml" \
+                       run --rm -e PGPASSWORD=franklin \
+                       database psql -U franklin -h database
+    fi
+    exit
+fi

--- a/scripts/db-console
+++ b/scripts/db-console
@@ -7,6 +7,7 @@ function usage() {
     echo -n \
 "Usage: $(basename "$0")
 Use Docker Compose to enter a psql shell on the local database container
+Example: ./scripts/db-console
 "
 }
 

--- a/scripts/db-console
+++ b/scripts/db-console
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -eu
+set -e
+
+if [[ -n "${NASA_HSI_DEBUG}" ]]; then
+    set -x
+fi
 
 DIR="$(dirname "$0")"
 

--- a/scripts/migrate
+++ b/scripts/migrate
@@ -4,8 +4,8 @@ set -e
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Use Docker Compose to start the app services
-Example: ./scripts/console
+Run database migrations
+Example: ./scripts/migrate
 "
 }
 

--- a/scripts/migrate
+++ b/scripts/migrate
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if [[ -n "${NASA_HSI_DEBUG}" ]]; then
+    set -x
+fi
+
 function usage() {
     echo -n \
 "Usage: $(basename "$0")

--- a/scripts/migrate
+++ b/scripts/migrate
@@ -4,7 +4,7 @@ set -e
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Use Docker Compose to drop into a console in the dev container
+Use Docker Compose to start the app services
 Example: ./scripts/console
 "
 }
@@ -16,7 +16,7 @@ then
             usage
             ;;
         *)
-            docker-compose run --rm --entrypoint /bin/bash dev
+            docker-compose run --rm franklin migrate
             ;;
     esac
 fi

--- a/scripts/run-activator-aviris-l2
+++ b/scripts/run-activator-aviris-l2
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Use Docker Compose to run the AVIRIS L2 activator
+Example: ./scripts/run-activator-aviris-l2 <AVIRIS STAC Item ID>
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    case "${1}" in
+        --help)
+            usage
+            ;;
+        *)
+
+            DEV_S3_BUCKET="aviris-data-${USER}"
+
+
+            docker-compose run --rm \
+                --entrypoint python \
+                --workdir="/workspace/pipeline/activators/aviris-l2" \
+                -e "AAL2_S3_BUCKET=${DEV_S3_BUCKET}" \
+                app main.py "$@"
+            ;;
+    esac
+fi

--- a/scripts/run-activator-aviris-l2
+++ b/scripts/run-activator-aviris-l2
@@ -14,7 +14,9 @@ then
     DEV_S3_BUCKET="aviris-data-dev-${USER}"
 
     if ! docker-compose run --rm --entrypoint aws dev s3 ls "s3://${DEV_S3_BUCKET}"; then
-        echo "Please create your dev S3 bucket s3://${DEV_S3_BUCKET} with the AWS CLI and then retry this command."
+        echo "Creating developer S3 bucket: s3://${DEV_S3_BUCKET}..."
+        docker-compose run --rm --entrypoint aws dev s3api create-bucket --bucket "${DEV_S3_BUCKET}"
+        echo "Done."
         exit 1
     fi
 

--- a/scripts/run-activator-aviris-l2
+++ b/scripts/run-activator-aviris-l2
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if [[ -n "${NASA_HSI_DEBUG}" ]]; then
+    set -x
+fi
+
 function usage() {
     echo -n \
 "Usage: $(basename "$0") --help

--- a/scripts/run-activator-aviris-l2
+++ b/scripts/run-activator-aviris-l2
@@ -3,7 +3,7 @@ set -e
 
 function usage() {
     echo -n \
-"Usage: $(basename "$0")
+"Usage: $(basename "$0") --help
 Use Docker Compose to run the AVIRIS L2 activator
 Example: ./scripts/run-activator-aviris-l2 <AVIRIS STAC Item ID>
 "
@@ -11,20 +11,16 @@ Example: ./scripts/run-activator-aviris-l2 <AVIRIS STAC Item ID>
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
-    case "${1}" in
-        --help)
-            usage
-            ;;
-        *)
+    DEV_S3_BUCKET="aviris-data-dev-${USER}"
 
-            DEV_S3_BUCKET="aviris-data-${USER}"
+    if ! docker-compose run --rm --entrypoint aws dev s3 ls "s3://${DEV_S3_BUCKET}"; then
+        echo "Please create your dev S3 bucket s3://${DEV_S3_BUCKET} with the AWS CLI and then retry this command."
+        exit 1
+    fi
 
-
-            docker-compose run --rm \
-                --entrypoint python \
-                --workdir="/workspace/pipeline/activators/aviris-l2" \
-                -e "AAL2_S3_BUCKET=${DEV_S3_BUCKET}" \
-                app main.py "$@"
-            ;;
-    esac
+    docker-compose run --rm \
+        --entrypoint python \
+        --workdir="/workspace/pipeline/activators/aviris-l2" \
+        -e "AAL2_S3_BUCKET=${DEV_S3_BUCKET}" \
+        app main.py "$@"
 fi

--- a/scripts/server
+++ b/scripts/server
@@ -4,7 +4,7 @@ set -e
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Use Docker Compose to drop into a console in the dev container
+Use Docker Compose to start the app services
 Example: ./scripts/console
 "
 }
@@ -16,7 +16,7 @@ then
             usage
             ;;
         *)
-            docker-compose run --rm --entrypoint /bin/bash dev
+            docker-compose up -d franklin
             ;;
     esac
 fi

--- a/scripts/server
+++ b/scripts/server
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if [[ -n "${NASA_HSI_DEBUG}" ]]; then
+    set -x
+fi
+
 function usage() {
     echo -n \
 "Usage: $(basename "$0")

--- a/scripts/setup
+++ b/scripts/setup
@@ -18,6 +18,8 @@ then
         *)
             docker-compose up -d database
             ./scripts/migrate
+            ./scripts/update
+
             ;;
     esac
 fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -4,8 +4,8 @@ set -e
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Use Docker Compose to drop into a console in the dev container
-Example: ./scripts/console
+Setup NASA development environment
+Example: ./scripts/setup
 "
 }
 
@@ -16,7 +16,8 @@ then
             usage
             ;;
         *)
-            docker-compose run --rm --entrypoint /bin/bash dev
+            docker-compose up -d database
+            ./scripts/migrate
             ;;
     esac
 fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if [[ -n "${NASA_HSI_DEBUG}" ]]; then
+    set -x
+fi
+
 function usage() {
     echo -n \
 "Usage: $(basename "$0")

--- a/scripts/update
+++ b/scripts/update
@@ -4,7 +4,7 @@ set -e
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Update all app services
+Update all containers
 Example: ./scripts/update
 "
 }

--- a/scripts/update
+++ b/scripts/update
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if [[ -n "${NASA_HSI_DEBUG}" ]]; then
+    set -x
+fi
+
 function usage() {
     echo -n \
 "Usage: $(basename "$0")

--- a/scripts/update
+++ b/scripts/update
@@ -4,8 +4,8 @@ set -e
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Use Docker Compose to drop into a console in the dev container
-Example: ./scripts/console
+Update all app services
+Example: ./scripts/update
 "
 }
 
@@ -16,7 +16,7 @@ then
             usage
             ;;
         *)
-            docker-compose run --rm --entrypoint /bin/bash dev
+            docker-compose build
             ;;
     esac
 fi


### PR DESCRIPTION
# Overview

This PR implements a Python activator that takes an AVIRIS STAC
Item Id and performs the following steps in order:

1. Pull refl archive from FTP
2. Unzip archive in temp dir
3. Convert all HDR files in archive to DEFLATE COGs
4. Create a STAC Item
5. Add STAC Asset for each created COG
6. Upload each COG to S3
7. Create STAC Item by POST to Franklin
8. Print new STAC Item URL

Script exits 0 on success, non-zero on any failure by throwing exceptions. We can adjust later once it's clearer what the specifics of the environment we'll be running in look like, but for now we have an adaptable baseline.

Closes #55 

## Demo

In this first screenshot, we trigger the job but get an error:

![Screen Shot 2020-12-07 at 6 21 37 PM](https://user-images.githubusercontent.com/1818302/101490364-3c6e3100-3930-11eb-9ee9-29f92002ba43.png)

With the options we've selected (`--temp-dir data --keep-temp-dir`) we can resume where we left off after fixing the bug:

![Screen Shot 2020-12-07 at 6 05 14 PM](https://user-images.githubusercontent.com/1818302/101490361-3c6e3100-3930-11eb-8bbf-09f189a4930c.png)

I also provided `--skip-large` which skips translate of the 8GB HDR file, which would take ~40mins on my laptop.

## Notes

The dev instructions below provide some options to the task that allow incremental retries so that a developer doesn't have to continually redownload or specify the location of the tar.gz file. Don't forget to clean up whatever temp dir you set when done developing.

There are some improvements to be made to the developer workflow for these, but I hesitated to do so now, before knowing what the infrastructure will look like. Some of these tasks include:
- [x] Add Franklin instance to docker-compose and configure for running pipelines
- [ ] ~~Adjust error handling for chosen pipeline infrastructure~~
- [x] Add a STRTA for running a pipeline job

Running the activator job in MacOS Docker takes _forever_ and Docker spins the CPU the whole time, presumably due to work being done to the volume mount when I set `--temp-dir ./data`. If you don't care about intermediate results, you can run the job without this arg and it should go faster, but if you want to re-run the job you'll need to download the FTP archive each time.

Running a job locally is an exercise in patience. We'll very quickly need to migrate running this job to Batch even in dev, or further improve the local experience.

## Testing Instructions

Follow the new steps in the README to setup the dev env. Copied here that's:
```
./scripts/setup
./scripts/server
./scripts/catalogs-aviris
```

Then you should be able to hit http://localhost:9090 and see the AVIRIS collection.

Finally run the task:
`./scripts/run-activator-aviris-l2 aviris_f130329t01p00r06_sc01 --temp-dir ./data --skip-large --keep-temp-dir`
...and go bake a cake.

When the activator finally finishes, you should be able to visit the URL printed by the script and see a STAC Item contained in a new `aviris-l2-cogs` collection!

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] README.md updated if necessary to reflect the changes
