### PR TITLE
Set up image publishing and GitHub Actions CI

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,9 +13,6 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     env:
-      # Set this to an empty string to avoid a ProfileNotFound exception from
-      # the AWS CLI
-      AWS_PROFILE: ""
       DOCKER_BUILDKIT: 1
     steps:
       - uses: actions/checkout@v2
@@ -30,10 +27,13 @@ jobs:
 
       - run: ./scripts/cipublish
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/jrb/ci'
-        env:
-          NASA_HSI_AWS_ECR_ENDPOINT: ${{ secrets.NASA_HSI_AWS_ECR_ENDPOINT }}
 
       - run: |
-          docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
-          docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply
+          docker-compose -f docker-compose.ci.yml run --rm terraform -c "
+            # Unset this to avoid a ProfileNotFound exception from the AWS CLI.
+            unset AWS_PROFILE
+
+            ./scripts/infra plan
+            ./scripts/infra apply
+          "
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/jrb/ci'

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,6 +13,9 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     env:
+      # Set this to an empty string to avoid a ProfileNotFound exception from
+      # the AWS CLI
+      AWS_PROFILE: ""
       DOCKER_BUILDKIT: 1
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - jrb/ci
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - run: ./scripts/cibuild
+
+      - run: ./scripts/cipublish
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/jrb/ci'
+        env:
+          NASA_HSI_AWS_ECR_ENDPOINT: ${{ secrets.NASA_HSI_AWS_ECR_ENDPOINT }}
+
+      - run: |
+          docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
+          docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/jrb/ci'

--- a/README.md
+++ b/README.md
@@ -1,33 +1,46 @@
-# NASA SBIR - Hyperspectral Imagery Processing
+# NASA SBIR — Hyperspectral Imagery Processing
 
-An event-driven image processing pipeline for developing our foundational capability to work with HSI data sources.
+An event-driven image processing pipeline for developing our foundational
+capability to work with HSI data sources.
 
-- [STAC Catalogs](#stac-catalogs)
+- [Requirements](#requirements)
+- [Getting Started](#getting-started)
 - [Scripts](#scripts)
 
 ## Requirements
 
-- Docker
-- Docker Compose
+- [Docker Engine](https://docs.docker.com/install/) 19.03+
+- [Docker Compose](https://docs.docker.com/compose/install/) 1.27+
 
-## Setup
+## Getting Started
 
-Run `./scripts/setup`.
+The following script will provision the development environment.
 
-## Development
+```bash
+$ ./scripts/setup
+```
 
-Run the local Franklin instance with `./scripts/server`. It is available at http://localhost:9090.
+Then, you can bring up the local Franklin instance, which will be accessible at
+http://localhost:9090.
 
-See READMEs in src directories for instructions on how to run individual services in this application.
+
+```bash
+$ ./scripts/server
+```
+
+See READMEs in the `src/` directories for instructions on how to run individual
+services in this application.
 
 ## Scripts
 
-| Name    | Description                                                 |
-|---------|-------------------------------------------------------------|
-| `console` | Open a shell in the `dev` container |
-| `db-console` | Open a psql shell on the `database` container |
-| `infra` | Execute Terraform subcommands with remote state management. |
-| `migrate` | Run database migrations |
-| `server` | Start application servers, including Franklin |
-| `setup` | Run project setup after checkout |
-| `update` | Update project dependencies and rebuild containers |
+| Name         | Description                                                                        |
+|--------------|------------------------------------------------------------------------------------|
+| `cibuild`    | Build application for staging or a release.                                        |
+| `cipublish`  | Publish container images to Elastic Container Registry (ECR).                      |
+| `console`    | Run an interactive shell or command inside an application container.               |
+| `db-console` | Enter a database shell.                                                            |
+| `infra`      | Execute Terraform subcommands with remote state management.                        |
+| `migrate`    | Run database migrations.                                                           |
+| `server`     | Start application servers, including Franklin.                                     |
+| `setup`      | Set up the project's development environment.                                      |
+| `update`     | Update project runtime dependencies (e.g. run migrations, build container images). |

--- a/deployment/terraform/.terraform.lock.hcl
+++ b/deployment/terraform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.22.0"
+  constraints = ">= 2.33.0, >= 3.0.0, ~> 3.22"
+  hashes = [
+    "h1:8aWXjFcmEi64P0TMHOCQXWws+/SmvJQrNvHlzdktKOM=",
+    "zh:4a9a66caf1964cdd3b61fb3ebb0da417195a5529cb8e496f266b0778335d11c8",
+    "zh:514f2f006ae68db715d86781673faf9483292deab235c7402ff306e0e92ea11a",
+    "zh:5277b61109fddb9011728f6650ef01a639a0590aeffe34ed7de7ba10d0c31803",
+    "zh:67784dc8c8375ab37103eea1258c3334ee92be6de033c2b37e3a2a65d0005142",
+    "zh:76d4c8be2ca4a3294fb51fb58de1fe03361d3bc403820270cc8e71a04c5fa806",
+    "zh:8f90b1cfdcf6e8fb1a9d0382ecaa5056a3a84c94e313fbf9e92c89de271cdede",
+    "zh:d0ac346519d0df124df89be2d803eb53f373434890f6ee3fb37112802f9eac59",
+    "zh:d6256feedada82cbfb3b1dd6dd9ad02048f23120ab50e6146a541cb11a108cc1",
+    "zh:db2fe0d2e77c02e9a74e1ed694aa352295a50283f9a1cf896e5be252af14e9f4",
+    "zh:eda61e889b579bd90046939a5b40cf5dc9031fb5a819fc3e4667a78bd432bdb2",
+  ]
+}

--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "batch" {
 
 # Pull the image ID for the latest Amazon ECS optimized AMI
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
-data "aws_ssm_parameter" batch_ami_id {
+data "aws_ssm_parameter" "batch_ami_id" {
   name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
 }
 

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.11"
+      version = "~> 3.22"
     }
   }
 }

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -1,0 +1,6 @@
+module "activator_aviris_l2" {
+  source = "github.com/azavea/terraform-aws-ecr-repository?ref=1.0.0"
+
+  repository_name         = "activator-aviris-l2"
+  attach_lifecycle_policy = true
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -40,7 +40,8 @@ variable "vpc_cidr_block" {
 }
 
 variable "external_access_cidr_block" {
-  type = string
+  type      = string
+  sensitive = true
 }
 
 variable "vpc_private_subnet_cidr_blocks" {
@@ -101,11 +102,13 @@ variable "rds_database_name" {
 }
 
 variable "rds_database_username" {
-  type = string
+  type      = string
+  sensitive = true
 }
 
 variable "rds_database_password" {
-  type = string
+  type      = string
+  sensitive = true
 }
 
 variable "rds_backup_retention_period" {

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,13 +1,16 @@
 version: "3.8"
 services:
+  activator-aviris-l2:
+    image: "activator-aviris-l2:${GIT_COMMIT:-latest}"
+
   terraform:
-    image: quay.io/azavea/terraform:0.13.5
+    image: quay.io/azavea/terraform:0.14.3
     volumes:
       - ./:/usr/local/src
       - $HOME/.aws:/root/.aws:ro
     environment:
-      - AWS_PROFILE=${AWS_PROFILE:-nasa-hsi}
-      - GIT_COMMIT=${GIT_COMMIT:-latest}
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
       - NASA_HSI_DEBUG=1
       - NASA_HSI_SETTINGS_BUCKET=${NASA_HSI_SETTINGS_BUCKET:-nasahyperspectral-staging-config-us-east-1}
     working_dir: /usr/local/src

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -12,6 +12,8 @@ services:
       - AWS_PROFILE=${AWS_PROFILE:-nasa}
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
+      - AWS_DEFAULT_REGION
+      - AWS_REGION
       - NASA_HSI_DEBUG=1
       - NASA_HSI_SETTINGS_BUCKET=${NASA_HSI_SETTINGS_BUCKET:-nasahyperspectral-staging-config-us-east-1}
     working_dir: /usr/local/src

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -9,6 +9,7 @@ services:
       - ./:/usr/local/src
       - $HOME/.aws:/root/.aws:ro
     environment:
+      - AWS_PROFILE=${AWS_PROFILE:-nasa}
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - NASA_HSI_DEBUG=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     volumes:
       - ./src/catalogs/aviris:/usr/local/src
       - $HOME/.aws:/root/.aws:ro
+      - conda-pkg-cache:/opt/conda/pkgs
 
   activator-aviris-l2:
     image: activator-aviris-l2
@@ -43,8 +44,8 @@ services:
     volumes:
       - ./src/pipeline/activator/aviris-l2:/usr/local/src
       - ./pipeline-data:/data
-      - /opt/conda/pkgs:/opt/conda/pkgs
       - $HOME/.aws:/root/.aws:ro
+      - conda-pkg-cache:/opt/conda/pkgs
 
   shellcheck:
     image: koalaman/shellcheck:stable
@@ -65,7 +66,12 @@ services:
     volumes:
       - ./:/usr/local/src
       - ./pipeline-data:/data
-      - /opt/conda/pkgs:/opt/conda/pkgs
       - $HOME/.aws:/root/.aws:ro
+      - conda-pkg-cache:/opt/conda/pkgs
     environment:
       - AWS_PROFILE=${AWS_PROFILE:-nasa}
+
+volumes:
+  # Persist the Conda package cache as a named volume. This package cache will
+  # only be accessible when invoking Conda in-container.
+  conda-pkg-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - POSTGRES_USER=franklin
       - POSTGRES_PASSWORD=franklin
       - POSTGRES_DB=franklin
+
   franklin:
     image: quay.io/azavea/franklin:c93f2ff
     command: ["serve", "--with-transactions"]
@@ -20,38 +21,51 @@ services:
       - AWS_REGION
     ports:
       - "9090:9090"
+
   catalogs-aviris:
+    image: nasa-hsi-catalogs-aviris
     build:
       context: ./src/catalogs/aviris
     environment:
       - AWS_PROFILE=${AWS_PROFILE:-nasa}
-    image: nasa-hsi-catalogs-aviris
     volumes:
       - ./src/catalogs/aviris:/usr/local/src
       - $HOME/.aws:/root/.aws:ro
+
   activator-aviris-l2:
+    image: activator-aviris-l2
     build:
       context: ./src/pipeline/activator/aviris-l2
     environment:
       - AAL2_FRANKLIN_URL=http://franklin:9090
       - AAL2_S3_BUCKET=aviris-data-dev-${USER}
       - AWS_PROFILE=${AWS_PROFILE:-nasa}
-    image: nasa-hsi-activator-aviris-l2
     volumes:
       - ./src/pipeline/activator/aviris-l2:/usr/local/src
       - ./pipeline-data:/data
+      - /opt/conda/pkgs:/opt/conda/pkgs
       - $HOME/.aws:/root/.aws:ro
+
+  shellcheck:
+    image: koalaman/shellcheck:stable
+    volumes:
+      - ./:/usr/local/src
+    working_dir: /usr/local/src
+  
+  black:
+    image: cytopia/black
+    volumes:
+      - ./:/usr/local/src
+    working_dir: /usr/local/src
+
   dev:
     build:
       context: .
       dockerfile: Dockerfile.dev
     volumes:
       - ./:/usr/local/src
-      - conda-dev:/opt/conda
-      - pipeline-data:/data
+      - ./pipeline-data:/data
+      - /opt/conda/pkgs:/opt/conda/pkgs
       - $HOME/.aws:/root/.aws:ro
     environment:
       - AWS_PROFILE=${AWS_PROFILE:-nasa}
-volumes:
-  conda-dev:
-  pipeline-data:

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${NASA_HSI_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Build application for staging or a release.
+"
+}
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    if [[ "${1:-}" == "--help" ]]; then
+        usage
+    else
+        ./scripts/update
+
+        # Build tagged container images
+        GIT_COMMIT="${GIT_COMMIT}" docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.ci.yml \
+            build activator-aviris-l2
+
+        ./scripts/test
+    fi
+fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -19,23 +19,37 @@ else
     GIT_COMMIT="$(git rev-parse --short HEAD)"
 fi
 
+function amazon_ecr_login() {
+    # Retrieves a temporary authorization token that can be used to access
+    # Amazon ECR, along with the registry URL.
+    read -r AUTHORIZATION_TOKEN ECR_REGISTRY \
+        <<<"$(aws ecr get-authorization-token \
+            --output "text" \
+            --query "authorizationData[0].[authorizationToken, proxyEndpoint]")"
+
+    # The authorization token is base64 encoded, and we need to strip the
+    # protocol from the registry URL.
+    AUTHORIZATION_TOKEN="$(echo "${AUTHORIZATION_TOKEN}" | base64 -d)"
+    ECR_REGISTRY="${ECR_REGISTRY##*://}"
+
+    # Authenticate to the ECR registry.
+    docker login \
+        --username "${AUTHORIZATION_TOKEN%%:*}" \
+        --password "${AUTHORIZATION_TOKEN##*:}" \
+        "${ECR_REGISTRY}"
+}
+
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "${1:-}" == "--help" ]]; then
         usage
     else
-        if [[ -n "${NASA_HSI_AWS_ECR_ENDPOINT}" ]]; then
-            # Evaluate the return value of the get-login subcommand, which
-            # is a docker login command with temporarily ECR credentials.
-            eval "$(aws ecr get-login --no-include-email)"
+        # Login to Amazon ECR with the local Docker client.
+        amazon_ecr_login
 
-            # Tag and publish the Aviris L2 activator
-            docker tag "activator-aviris-l2:${GIT_COMMIT}" \
-                "${NASA_HSI_AWS_ECR_ENDPOINT}/activator-aviris-l2:${GIT_COMMIT}"
+        # Tag and publish the Aviris L2 activator.
+        docker tag "activator-aviris-l2:${GIT_COMMIT}" \
+            "${ECR_REGISTRY}/activator-aviris-l2:${GIT_COMMIT}"
 
-            docker push "${NASA_HSI_AWS_ECR_ENDPOINT}/activator-aviris-l2:${GIT_COMMIT}"
-        else
-            echo "ERROR: No NASA_HSI_AWS_ECR_ENDPOINT variable defined."
-            exit 1
-        fi
+        docker push "${ECR_REGISTRY}/activator-aviris-l2:${GIT_COMMIT}"
     fi
 fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -32,11 +32,12 @@ function amazon_ecr_login() {
     AUTHORIZATION_TOKEN="$(echo "${AUTHORIZATION_TOKEN}" | base64 -d)"
     ECR_REGISTRY="${ECR_REGISTRY##*://}"
 
-    # Authenticate to the ECR registry.
-    docker login \
-        --username "${AUTHORIZATION_TOKEN%%:*}" \
-        --password "${AUTHORIZATION_TOKEN##*:}" \
-        "${ECR_REGISTRY}"
+    # Authenticate to the ECR registry. The authorization token is presented in
+    # the format user:password.
+    echo "${AUTHORIZATION_TOKEN##*:}" |
+        docker login \
+            --username "${AUTHORIZATION_TOKEN%%:*}" \
+            --password-stdin "${ECR_REGISTRY}"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${NASA_HSI_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Publish container images to Elastic Container Registry (ECR).
+"
+}
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    if [[ "${1:-}" == "--help" ]]; then
+        usage
+    else
+        if [[ -n "${NASA_HSI_AWS_ECR_ENDPOINT}" ]]; then
+            # Evaluate the return value of the get-login subcommand, which
+            # is a docker login command with temporarily ECR credentials.
+            eval "$(aws ecr get-login --no-include-email)"
+
+            # Tag and publish the Aviris L2 activator
+            docker tag "activator-aviris-l2:${GIT_COMMIT}" \
+                "${NASA_HSI_AWS_ECR_ENDPOINT}/activator-aviris-l2:${GIT_COMMIT}"
+
+            docker push "${NASA_HSI_AWS_ECR_ENDPOINT}/activator-aviris-l2:${GIT_COMMIT}"
+        else
+            echo "ERROR: No NASA_HSI_AWS_ECR_ENDPOINT variable defined."
+            exit 1
+        fi
+    fi
+fi

--- a/scripts/console
+++ b/scripts/console
@@ -10,10 +10,11 @@ function usage() {
     echo -n \
         "Usage: $(basename "$0") SERVICE [COMMAND]...
 Run an interactive shell or command inside an application container.
-Example: ./scripts/console dev
+Example: ./scripts/console app
+
 Services:
-    app         App container
-    dev         Dev container
+    app App container
+    dev Dev container
 "
 }
 

--- a/scripts/db-console
+++ b/scripts/db-console
@@ -10,7 +10,7 @@ DIR="$(dirname "$0")"
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Use Docker Compose to enter a psql shell on the local database container
+Enter a database shell.
 Example: ./scripts/db-console
 "
 }

--- a/scripts/migrate
+++ b/scripts/migrate
@@ -8,7 +8,7 @@ fi
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Run database migrations
+Run database migrations.
 Example: ./scripts/migrate
 "
 }

--- a/scripts/server
+++ b/scripts/server
@@ -8,7 +8,7 @@ fi
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Use Docker Compose to start the app services
+Start application servers, including Franklin.
 Example: ./scripts/console
 "
 }

--- a/scripts/setup
+++ b/scripts/setup
@@ -20,8 +20,6 @@ then
             usage
             ;;
         *)
-            docker-compose up -d database
-            ./scripts/migrate
             ./scripts/update
 
             ;;

--- a/scripts/setup
+++ b/scripts/setup
@@ -8,8 +8,7 @@ fi
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Setup NASA development environment
-Example: ./scripts/setup
+Set up the project's development environment.
 "
 }
 

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${NASA_HSI_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Run tests.
+"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    if [[ "${1:-}" == "--help" ]]; then
+        usage
+    else
+        # Lint Bash scripts
+        docker-compose \
+            run --rm --no-deps shellcheck \
+            scripts/*
+
+        # Lint Python
+        # docker-compose \
+        #     run --rm --no-deps \
+        #     black --check --diff .
+    fi
+fi

--- a/scripts/update
+++ b/scripts/update
@@ -20,6 +20,9 @@ then
             usage
             ;;
         *)
+            docker-compose up -d database
+            ./scripts/migrate
+            
             docker-compose build
             ;;
     esac

--- a/scripts/update
+++ b/scripts/update
@@ -8,7 +8,7 @@ fi
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Update all containers
+Update project runtime dependencies (e.g. run migrations, build container images).
 Example: ./scripts/update
 "
 }


### PR DESCRIPTION
## Overview

- Build and publish the Aviris L2 Activator image
- Use [ShellCheck](https://github.com/koalaman/shellcheck) and [Black](https://pypi.org/project/black/) to lint project sources
- Add Terraform for the Aviris L2 Activator ECR repository
- Upgrade Terraform and the AWS provider to enable support for [sensitive input variables](https://www.hashicorp.com/blog/terraform-0-14-adds-the-ability-to-redact-sensitive-values-in-console-output)
- Create GitHub Actions CI workflow

Resolves #49

## Notes

The container image build takes around 10 minutes. I believe part of this is due to Conda's methods of achieving reproducible builds by downloading and sandboxing multiple copies of the same dependencies. 

The same thing happens when I build the image on my workstation, but Docker layer caching can speed things up quite a bit, and invoking Conda within the image itself allows us to use the package cache.

I tried using the [satackey/action-docker-layer-caching](https://github.com/satackey/action-docker-layer-caching
) action. This sped up the container build but at the cost of an equivalent amount of time fetching from the cache.

I think these performance issues should be investigated in isolation. When you think of how many modules may be a part of this pipeline, we could see a multiplicative effect.

cc: @CloudNiner 

## Testing Instructions

See successful CI checks below.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] README.md updated if necessary to reflect the changes
