### PR TITLE
Run migrations at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ services in this application.
 | `server`     | Start application servers, including Franklin.                                     |
 | `setup`      | Set up the project's development environment.                                      |
 | `update`     | Update project runtime dependencies (e.g. run migrations, build container images). |
+| `edit-tfvars`| Safely make changes to variables that affect deployment                            |

--- a/deployment/terraform/task-definitions/franklin.json.tmpl
+++ b/deployment/terraform/task-definitions/franklin.json.tmpl
@@ -18,7 +18,8 @@
       "--external-port",
       "443",
       "--with-transactions",
-      "--with-tiles"
+      "--with-tiles",
+      "--run-migrations"
     ],
     "environment": [
       {

--- a/scripts/edit-tfvars
+++ b/scripts/edit-tfvars
@@ -16,7 +16,7 @@ cp -f "${TO_EDIT_TMP_FILE}" "${TO_COMPARE_TMP_FILE}"
 
 if ! cmp --silent "${TO_EDIT_TMP_FILE}" "${TO_COMPARE_TMP_FILE}"; then
   echo
-  (diff -a "${TO_EDIT_TMP_FILE}" "${TO_COMPARE_TMP_FILE}") || true
+  (diff -u -a "${TO_EDIT_TMP_FILE}" "${TO_COMPARE_TMP_FILE}") || true
   echo
   read -p "Does that look reasonable? (y/n) " -n 1 -r
   echo

--- a/scripts/edit-tfvars
+++ b/scripts/edit-tfvars
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -ex
+
+TO_EDIT_TMP_FILE=$(mktemp)
+
+TFVARS_S3_PATH="s3://nasahyperspectral-staging-config-us-east-1/terraform/terraform.tfvars"
+
+TO_COMPARE_TMP_FILE=$(mktemp)
+
+aws --quiet s3 cp --sse AES256 "${TFVARS_S3_PATH}" "${TO_EDIT_TMP_FILE}"
+
+cp -f "${TO_EDIT_TMP_FILE}" "${TO_COMPARE_TMP_FILE}"
+
+"${EDITOR}" "${TO_EDIT_TMP_FILE}"
+
+if ! cmp --silent "${TO_EDIT_TMP_FILE}" "${TO_COMPARE_TMP_FILE}"; then
+  echo
+  (diff -a "${TO_EDIT_TMP_FILE}" "${TO_COMPARE_TMP_FILE}") || true
+  echo
+  read -p "Does that look reasonable? (y/n) " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    aws --quiet s3 cp --sse AES256 "${TO_EDIT_TMP_FILE}" "${TFVARS_S3_PATH}"
+  fi
+else
+  echo "No changes to upload"
+fi


### PR DESCRIPTION
## Overview

This PR adds the `--run-migrations` flag to Franklin startup. With `--run-migrations`, the server process will apply any outstanding migrations before it starts up.

It also adds the `edit-tfvars` script that we have in the Raster Foundry deployment repo, which has made it much safer for us to edit tfvars in that context.

## Testing Instructions

 * confirm that the Franklin hash matches the latest Franklin `master` build -- you can do this with `EDITOR=vi AWS_PROFILE=nasa-hyper ./scripts/edit-tfvars`, which will pull the current tfvars. If you don't make any edits, nothing will be pushed back to s3

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] README.md updated if necessary to reflect the changes
