### PR TITLE
Move project to Scala 2.13 and JDK11

### DIFF
--- a/src/pipeline/activator/cog-clip/.sbtopts
+++ b/src/pipeline/activator/cog-clip/.sbtopts
@@ -1,0 +1,4 @@
+-J-Xmx2G
+-J-Xms1G
+-J-Xss5M
+-J-XX:+UseG1GC

--- a/src/pipeline/activator/cog-clip/Dockerfile
+++ b/src/pipeline/activator/cog-clip/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/openjdk-gdal:3.1-jdk8-slim
+FROM quay.io/azavea/openjdk-gdal:3.1-jdk11-slim
 
 RUN set -ex \
       && addgroup --system nasa-hyperspectral \
@@ -11,9 +11,9 @@ RUN set -ex \
         --ingroup nasa-hyperspectral \
         nasa-hyperspectral
 
-COPY ./target/scala-2.12/cog-clip-assembly.jar /var/lib/nasa-hyperspectral/
+COPY ./target/scala-2.13/cog-clip-assembly.jar /var/lib/nasa-hyperspectral/
 
 USER nasa-hyperspectral
 WORKDIR /var/lib/nasa-hyperspectral
 
-ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar", "cog-clip-assembly.jar"]
+ENTRYPOINT ["java", "-XX:+UseG1GC", "-jar", "cog-clip-assembly.jar"]

--- a/src/pipeline/activator/cog-clip/src/main/scala/com/azavea/nasa/hsi/commands/package.scala
+++ b/src/pipeline/activator/cog-clip/src/main/scala/com/azavea/nasa/hsi/commands/package.scala
@@ -54,7 +54,7 @@ package object commands {
 
   implicit val featureCollectionArgument: Argument[JsonFeatureCollection] =
     Argument.from("""{ "type": "FeatureCollection", "features": [<features>] }""") { string =>
-      Try(string.stripMargin.parseGeoJson[JsonFeatureCollection]).toValidated
+      Try(string.stripMargin.parseGeoJson[JsonFeatureCollection]()).toValidated
         .leftMap(e => NonEmptyList.one(e.getMessage))
     }
 


### PR DESCRIPTION
## Overview

This PR adds Scala 2.13 corss compilation (and makes it default). Scala 2.12 is not dropped yet to have a safe rollback to 2.12. 
