### PR TITLE
Move all logging on the logger shoulders in order not to break stdout

### DIFF
--- a/src/pipeline/activator/aviris-l1/main.py
+++ b/src/pipeline/activator/aviris-l1/main.py
@@ -463,12 +463,14 @@ def main():
         for idx, hdr_file_w_ext in enumerate(hdr_files):
             hdr_file_w_ext_path = Path(hdr_file_w_ext)
             hdr_path = Path(extract_path, hdr_file_w_ext_path.with_suffix(""))
-            # cog_path = hdr_path.with_suffix(".tiff")
             cog_path = Path(f'{hdr_path.with_suffix("")}_{args.output_asset_name}.tiff')
 
             # Convert HDR data to pixel interleaved COG with GDAL
             # NUM_THREADS only speeds up compression and overview generation
             # gdal.Warp is used to fix rasters rotation
+            # NOTE: 
+            # We can't directly write TIFFs on S3 as the result of the gdal.Warp operation
+            # see: https://github.com/OSGeo/gdal/issues/1189
             warp_opts = gdal.WarpOptions(
                 callback=warp_callback,
                 warpOptions=["NUM_THREADS=ALL_CPUS"],

--- a/src/pipeline/activator/aviris-l1/main.py
+++ b/src/pipeline/activator/aviris-l1/main.py
@@ -464,7 +464,7 @@ def main():
             hdr_file_w_ext_path = Path(hdr_file_w_ext)
             hdr_path = Path(extract_path, hdr_file_w_ext_path.with_suffix(""))
             # cog_path = hdr_path.with_suffix(".tiff")
-            cog_path = f'{hdr_path.with_suffix("")}_{args.output_asset_name}.tiff'
+            cog_path = Path(f'{hdr_path.with_suffix("")}_{args.output_asset_name}.tiff')
 
             # Convert HDR data to pixel interleaved COG with GDAL
             # NUM_THREADS only speeds up compression and overview generation

--- a/src/pipeline/activator/aviris-l2/main.py
+++ b/src/pipeline/activator/aviris-l2/main.py
@@ -473,7 +473,7 @@ def main():
             hdr_file_w_ext_path = Path(hdr_file_w_ext)
             hdr_path = Path(extract_path, hdr_file_w_ext_path.with_suffix(""))
             # cog_path = hdr_path.with_suffix(".tiff")
-            cog_path = f'{hdr_path.with_suffix("")}_{args.output_asset_name}.tiff'
+            cog_path = Path(f'{hdr_path.with_suffix("")}_{args.output_asset_name}.tiff')
 
             if args.skip_large and os.path.getsize(hdr_path) > 0.2 * GB:
                 file_mb = floor(os.path.getsize(hdr_path) / 1024 / 1024)

--- a/src/pipeline/activator/aviris-l2/main.py
+++ b/src/pipeline/activator/aviris-l2/main.py
@@ -472,7 +472,6 @@ def main():
         for idx, hdr_file_w_ext in enumerate(hdr_files):
             hdr_file_w_ext_path = Path(hdr_file_w_ext)
             hdr_path = Path(extract_path, hdr_file_w_ext_path.with_suffix(""))
-            # cog_path = hdr_path.with_suffix(".tiff")
             cog_path = Path(f'{hdr_path.with_suffix("")}_{args.output_asset_name}.tiff')
 
             if args.skip_large and os.path.getsize(hdr_path) > 0.2 * GB:
@@ -487,6 +486,9 @@ def main():
             # Convert HDR data to pixel interleaved COG with GDAL
             # NUM_THREADS only speeds up compression and overview generation
             # gdal.Warp is used to fix rasters rotation
+            # NOTE: 
+            # We can't directly write TIFFs on S3 as the result of the gdal.Warp operation
+            # see: https://github.com/OSGeo/gdal/issues/1189
             warp_opts = gdal.WarpOptions(
                 callback=warp_callback,
                 warpOptions=["NUM_THREADS=ALL_CPUS"],

--- a/src/pipeline/activator/prisma/main.py
+++ b/src/pipeline/activator/prisma/main.py
@@ -299,6 +299,9 @@ def main():
                 format=args.output_format
             )
             logger.info(f'Converting {str(path)} to {cog_path}...')
+            # NOTE: 
+            # We can't directly write TIFFs on S3 as the result of the gdal.Warp operation
+            # see: https://github.com/OSGeo/gdal/issues/1189
             with timing("GDAL Warp"):
                 gdal.Warp(str(cog_path), str(path), options=warp_opts)
 


### PR DESCRIPTION
## Overview

At this points containers logging breaks both Argo logging and Lens logging. This is an attempt to fix it and make logs more readable.

Connects #166

