### PR TITLE
Update Argo CLI used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install Argo CLI
         run: |
-          curl -sLO https://github.com/argoproj/argo-workflows/releases/download/v3.2.6/argo-linux-amd64.gz && \
+          curl -sLO https://github.com/argoproj/argo-workflows/releases/download/v3.3.5/argo-linux-amd64.gz && \
           gunzip argo-linux-amd64.gz && \
           sudo chmod +x argo-linux-amd64 && \
           sudo mv ./argo-linux-amd64 /usr/local/bin/argo && \


### PR DESCRIPTION
## Overview

This PR is a follow up to the https://github.com/azavea/nasa-hyperspectral/pull/213 and updates the Argo CLI version used in CI.

